### PR TITLE
Add initial CLI skeleton for findsomething

### DIFF
--- a/cmd/findsomething-cli/main.go
+++ b/cmd/findsomething-cli/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"findsomething/internal/output"
+	"findsomething/internal/scan"
+)
+
+func main() {
+	format := flag.String("format", "json", "output format: pretty or json")
+	safe := flag.Bool("safe", true, "safe mode - only scan JS")
+	allowFile := flag.String("allow", "", "allowlist file")
+	rulesFile := flag.String("rules", "", "extra regex rules YAML")
+	outFile := flag.String("output", "", "output file (stdout default)")
+	quiet := flag.Bool("quiet", false, "suppress banner")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "usage: findsomething-cli [URL|PATH|-] [flags]")
+		os.Exit(2)
+	}
+
+	target := flag.Arg(0)
+	var input *bufio.Reader
+	var base string
+
+	if target == "-" {
+		input = bufio.NewReader(os.Stdin)
+		base = "stdin"
+	} else if isURL(target) {
+		data, err := scan.FetchURL(target)
+		if err != nil {
+			log.Fatal(err)
+		}
+		input = bufio.NewReader(data)
+		base = target
+	} else {
+		f, err := os.Open(target)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		input = bufio.NewReader(f)
+		base = filepath.Base(target)
+	}
+
+	extractor := scan.NewExtractor(*safe)
+	if *rulesFile != "" {
+		if err := extractor.LoadRulesFile(*rulesFile); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if *allowFile != "" {
+		if err := extractor.LoadAllowlist(*allowFile); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	matches, err := extractor.ScanReader(base, input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var out *os.File = os.Stdout
+	if *outFile != "" {
+		f, err := os.Create(*outFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	printer := output.NewPrinter(*format, !*quiet)
+	if err := printer.Print(out, matches); err != nil {
+		log.Fatal(err)
+	}
+
+	if len(matches) > 0 {
+		os.Exit(1)
+	}
+}
+
+func isURL(s string) bool {
+	return len(s) > 4 && (s[:7] == "http://" || s[:8] == "https://")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module findsomething
+
+go 1.23.8

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -1,0 +1,32 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"findsomething/internal/scan"
+)
+
+// Printer handles output rendering
+type Printer struct {
+	format string
+	banner bool
+}
+
+// NewPrinter creates a printer
+func NewPrinter(format string, banner bool) *Printer {
+	return &Printer{format: format, banner: banner}
+}
+
+// Print writes matches to w
+func (p *Printer) Print(w io.Writer, matches []scan.Match) error {
+	if p.format == "pretty" {
+		for _, m := range matches {
+			fmt.Fprintf(w, "%s: [%s] %s\n", m.Source, m.Pattern, m.Value)
+		}
+		return nil
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(matches)
+}

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -1,0 +1,102 @@
+package scan
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Match represents a single regex hit
+type Match struct {
+	Source  string `json:"source"`
+	Pattern string `json:"pattern"`
+	Value   string `json:"value"`
+}
+
+// Extractor holds compiled regex patterns
+type Extractor struct {
+	patterns  map[string]*regexp.Regexp
+	safeMode  bool
+	allowlist []string
+}
+
+// default patterns (simplified)
+var defaultPatterns = map[string]string{
+	"email": `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`,
+	"ipv4":  `\b(?:\d{1,3}\.){3}\d{1,3}\b`,
+	"jwt":   `eyJ[a-zA-Z0-9_-]+?\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+`,
+}
+
+// NewExtractor creates an Extractor
+func NewExtractor(safe bool) *Extractor {
+	e := &Extractor{patterns: make(map[string]*regexp.Regexp), safeMode: safe}
+	for name, pat := range defaultPatterns {
+		e.patterns[name] = regexp.MustCompile(pat)
+	}
+	return e
+}
+
+// LoadRulesFile loads additional regex patterns from a YAML file
+func (e *Extractor) LoadRulesFile(path string) error {
+	// simple YAML key:value
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := bufio.NewScanner(bytes.NewReader(data))
+	for lines.Scan() {
+		line := lines.Text()
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return errors.New("invalid rules line")
+		}
+		name := strings.TrimSpace(parts[0])
+		pat := strings.TrimSpace(parts[1])
+		r, err := regexp.Compile(pat)
+		if err != nil {
+			return err
+		}
+		e.patterns[name] = r
+	}
+	return lines.Err()
+}
+
+// LoadAllowlist loads allowed domain suffixes
+func (e *Extractor) LoadAllowlist(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		e.allowlist = append(e.allowlist, line)
+	}
+	return sc.Err()
+}
+
+// ScanReader scans an io.Reader and returns matches
+func (e *Extractor) ScanReader(source string, r io.Reader) ([]Match, error) {
+	var matches []Match
+	buf := bufio.NewScanner(r)
+	for buf.Scan() {
+		line := buf.Text()
+		for name, re := range e.patterns {
+			for _, v := range re.FindAllString(line, -1) {
+				matches = append(matches, Match{Source: source, Pattern: name, Value: v})
+			}
+		}
+	}
+	return matches, buf.Err()
+}

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -1,0 +1,16 @@
+package scan
+
+import "testing"
+import "strings"
+
+func TestExtractor(t *testing.T) {
+	e := NewExtractor(true)
+	r := strings.NewReader("test email test@example.com and IP 1.2.3.4")
+	matches, err := e.ScanReader("test", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+}

--- a/internal/scan/fetch.go
+++ b/internal/scan/fetch.go
@@ -1,0 +1,25 @@
+package scan
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+// FetchURL retrieves the content at url with timeouts and limited redirects
+func FetchURL(url string) (io.Reader, error) {
+	client := http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/internal/scan/filewalk.go
+++ b/internal/scan/filewalk.go
@@ -1,0 +1,49 @@
+package scan
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var exts = []string{".html", ".js", ".ts", ".jsx"}
+
+// WalkDir walks directory and returns list of readers with their filenames
+func WalkDir(root string) (map[string]io.ReadCloser, error) {
+	files := make(map[string]io.ReadCloser)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if matchExt(path) {
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			files[path] = f
+		}
+		return nil
+	})
+	if err != nil {
+		for _, f := range files {
+			f.Close()
+		}
+		return nil, err
+	}
+	return files, nil
+}
+
+func matchExt(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, e := range exts {
+		if ext == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- initialize Go module and add simple CLI
- implement extractor with default regexes and loading of YAML rules and allowlist
- add helper utilities for fetching URLs, walking directories, and printing output
- include a basic unit test for extractor

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dc079252c8331a81cd3e5ef0804b9