### PR TITLE
Improve archive scanning and concurrency

### DIFF
--- a/internal/scan/dirscan.go
+++ b/internal/scan/dirscan.go
@@ -1,0 +1,68 @@
+package scan
+
+import (
+	"io"
+	"sync"
+)
+
+// ScanDir scans all supported files under root directory using workers
+// to limit concurrency.
+func (e *Extractor) ScanDir(root string, workers int) ([]Match, error) {
+	files, err := WalkDir(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		for _, f := range files {
+			f.Close()
+		}
+	}()
+
+	if workers <= 0 {
+		workers = 1
+	}
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	matchesCh := make(chan []Match, len(files))
+	errCh := make(chan error, len(files))
+
+	for name, r := range files {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(n string, rc io.ReadCloser) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer rc.Close()
+
+			ms, err := e.ScanReader(n, rc)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if len(ms) > 0 {
+				matchesCh <- ms
+			}
+		}(name, r)
+	}
+
+	go func() {
+		wg.Wait()
+		close(matchesCh)
+		close(errCh)
+	}()
+
+	var matches []Match
+	for m := range matchesCh {
+		matches = append(matches, m...)
+	}
+
+	var firstErr error
+	for err := range errCh {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return matches, firstErr
+}

--- a/internal/scan/dirscan_test.go
+++ b/internal/scan/dirscan_test.go
@@ -1,0 +1,47 @@
+package scan
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanDir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "scandir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// regular JS file
+	os.WriteFile(filepath.Join(dir, "a.js"), []byte("test@test.com"), 0644)
+	// wasm file
+	os.WriteFile(filepath.Join(dir, "b.wasm"), []byte("1.2.3.4"), 0644)
+
+	// zip archive
+	zipPath := filepath.Join(dir, "c.zip")
+	createZip(zipPath, "c.js", "5.6.7.8")
+
+	// jar archive
+	jarPath := filepath.Join(dir, "d.jar")
+	createZip(jarPath, "d.js", "9.8.7.6")
+
+	e := NewExtractor(true)
+	matches, err := e.ScanDir(dir, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 4 {
+		t.Fatalf("expected 4 matches, got %d", len(matches))
+	}
+}
+
+func createZip(path, name, content string) {
+	f, _ := os.Create(path)
+	zw := zip.NewWriter(f)
+	w, _ := zw.Create(name)
+	w.Write([]byte(content))
+	zw.Close()
+	f.Close()
+}

--- a/internal/scan/filewalk.go
+++ b/internal/scan/filewalk.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"archive/zip"
+	"bytes"
 	"io"
 	"io/fs"
 	"os"
@@ -8,7 +10,7 @@ import (
 	"strings"
 )
 
-var exts = []string{".html", ".js", ".ts", ".jsx"}
+var exts = []string{".html", ".js", ".ts", ".jsx", ".wasm", ".zip", ".jar"}
 
 // WalkDir walks directory and returns list of readers with their filenames
 func WalkDir(root string) (map[string]io.ReadCloser, error) {
@@ -21,11 +23,35 @@ func WalkDir(root string) (map[string]io.ReadCloser, error) {
 			return nil
 		}
 		if matchExt(path) {
-			f, err := os.Open(path)
-			if err != nil {
-				return err
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext == ".zip" || ext == ".jar" {
+				zr, err := zip.OpenReader(path)
+				if err != nil {
+					return err
+				}
+				defer zr.Close()
+				for _, zf := range zr.File {
+					if matchExt(zf.Name) {
+						rc, err := zf.Open()
+						if err != nil {
+							return err
+						}
+						data, err := io.ReadAll(rc)
+						rc.Close()
+						if err != nil {
+							return err
+						}
+						name := path + ":" + zf.Name
+						files[name] = io.NopCloser(bytes.NewReader(data))
+					}
+				}
+			} else {
+				f, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				files[path] = f
 			}
-			files[path] = f
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- broaden recognized extensions to include `zip`, `jar` and `wasm`
- extract files from archives during directory walk
- allow concurrent scanning via new `ScanDir`
- test multi-file directory scanning including archives

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dc38ccbf0833189c68368130fe38b