### PR TITLE
Implement allowlist filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Flags:
 
 - `-format` output format, `pretty` or `json` (default `json`).
 - `-safe` safe mode - only scan JavaScript (default `true`).
-- `-allow` allowlist file.
+- `-allow` allowlist file. Entries are domain strings; matches from a source or
+  value containing any of these domains are ignored.
 - `-rules` extra regex rules YAML file.
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -14,3 +14,32 @@ func TestExtractor(t *testing.T) {
 		t.Fatalf("expected 2 matches, got %d", len(matches))
 	}
 }
+
+func TestAllowlistValue(t *testing.T) {
+	e := NewExtractor(true)
+	e.allowlist = []string{"example.com"}
+	r := strings.NewReader("email test@example.com and IP 1.2.3.4")
+	matches, err := e.ScanReader("src", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Pattern != "ipv4" {
+		t.Fatalf("expected ipv4 match, got %s", matches[0].Pattern)
+	}
+}
+
+func TestAllowlistSource(t *testing.T) {
+	e := NewExtractor(true)
+	e.allowlist = []string{"mysite.com"}
+	r := strings.NewReader("token eyJhbGciOiJ.test")
+	matches, err := e.ScanReader("mysite.com/script.js", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+}


### PR DESCRIPTION
## Summary
- filter matches by checking source and value against allowlist
- test allowlist functionality for source and value
- document how `-allow` works in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684dc38c20f88331bb395783caa32417