### PR TITLE
Implement safe mode filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ findsomething-cli [URL|PATH|-] [flags]
 Flags:
 
 - `-format` output format, `pretty` or `json` (default `json`).
-- `-safe` safe mode - only scan JavaScript (default `true`).
+- `-safe` safe mode - ignore non-JS files and patterns that aren't JavaScript specific (default `true`).
 - `-allow` allowlist file.
 - `-rules` extra regex rules YAML file.
 - `-output` write output to file instead of stdout.

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -1,12 +1,38 @@
 package scan
 
-import "testing"
-import "strings"
+import (
+	"strings"
+	"testing"
+)
 
-func TestExtractor(t *testing.T) {
+func TestScanSafeModeJSFile(t *testing.T) {
 	e := NewExtractor(true)
-	r := strings.NewReader("test email test@example.com and IP 1.2.3.4")
-	matches, err := e.ScanReader("test", r)
+	r := strings.NewReader("token eyJabc.def.ghi and email test@example.com")
+	matches, err := e.ScanReader("script.js", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Pattern != "jwt" {
+		t.Fatalf("expected jwt match only, got %+v", matches)
+	}
+}
+
+func TestScanSafeModeSkipFile(t *testing.T) {
+	e := NewExtractor(true)
+	r := strings.NewReader("eyJabc.def.ghi")
+	matches, err := e.ScanReader("notes.txt", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestScanUnsafeMode(t *testing.T) {
+	e := NewExtractor(false)
+	r := strings.NewReader("test@example.com and 1.2.3.4")
+	matches, err := e.ScanReader("file.txt", r)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- filter ScanReader results when safe mode is enabled
- document safe mode behavior
- add tests covering safe mode filtering

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dc38ad380833192549ba4c58b9534