### PR TITLE
Fix tests after safe mode change

### DIFF
--- a/internal/scan/dirscan_test.go
+++ b/internal/scan/dirscan_test.go
@@ -27,7 +27,7 @@ func TestScanDir(t *testing.T) {
 	jarPath := filepath.Join(dir, "d.jar")
 	createZip(jarPath, "d.js", "9.8.7.6")
 
-	e := NewExtractor(true)
+	e := NewExtractor(false)
 	matches, err := e.ScanDir(dir, 2)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -25,7 +25,7 @@ type Extractor struct {
 	allowlist []string
 }
 
-var jsExts = []string{".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"}
+var jsExts = []string{".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".wasm"}
 
 var jsRules = map[string]bool{
 	"jwt": true,


### PR DESCRIPTION
## Summary
- recognize WebAssembly as JS file
- update directory scan test to run in unsafe mode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dc6012dfc8331bdcaa6e7db9f9f5f