### PR TITLE
Implement allowlist skipping in extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Flags:
 
 - `-format` output format, `pretty` or `json` (default `json`).
 - `-safe` safe mode - ignore non-JS files and patterns that aren't JavaScript specific (default `true`).
-- `-allow` allowlist file.
+- `-allow` allowlist file. Sources whose names end with any suffix listed in this file are ignored.
 - `-rules` extra regex rules YAML file.
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -110,9 +110,22 @@ func isJSRule(name string) bool {
 	return jsRules[name]
 }
 
+func (e *Extractor) isAllowed(source string) bool {
+	for _, s := range e.allowlist {
+		if strings.HasSuffix(source, s) {
+			return true
+		}
+	}
+	return false
+}
+
 // ScanReader scans an io.Reader and returns matches
 func (e *Extractor) ScanReader(source string, r io.Reader) ([]Match, error) {
 	var matches []Match
+	if e.isAllowed(source) {
+		io.Copy(io.Discard, r)
+		return matches, nil
+	}
 	if e.safeMode && source != "stdin" && !isJSFile(source) {
 		io.Copy(io.Discard, r)
 		return matches, nil

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -70,3 +70,29 @@ func TestScanNewPatterns(t *testing.T) {
 		}
 	}
 }
+
+func TestAllowlistIgnore(t *testing.T) {
+	e := NewExtractor(false)
+	e.allowlist = []string{"allowed.js"}
+	r := strings.NewReader("eyJabc.def.ghi")
+	matches, err := e.ScanReader("allowed.js", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestAllowlistSuffix(t *testing.T) {
+	e := NewExtractor(false)
+	e.allowlist = []string{"ignored.js"}
+	r := strings.NewReader("eyJabc.def.ghi")
+	matches, err := e.ScanReader("/path/to/ignored.js", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+}


### PR DESCRIPTION
## Summary
- ignore matches from sources with allowlisted suffixes
- add unit tests for allowlist behavior
- document allowlist behaviour in usage notes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dc8ef60208331bf3977feb4f52f5d