### PR TITLE
Return ReadCloser from FetchURL

### DIFF
--- a/cmd/findsomething-cli/main.go
+++ b/cmd/findsomething-cli/main.go
@@ -34,11 +34,12 @@ func main() {
 		input = bufio.NewReader(os.Stdin)
 		base = "stdin"
 	} else if isURL(target) {
-		data, err := scan.FetchURL(target)
+		rc, err := scan.FetchURL(target)
 		if err != nil {
 			log.Fatal(err)
 		}
-		input = bufio.NewReader(data)
+		defer rc.Close()
+		input = bufio.NewReader(rc)
 		base = target
 	} else {
 		f, err := os.Open(target)

--- a/internal/scan/fetch.go
+++ b/internal/scan/fetch.go
@@ -7,7 +7,7 @@ import (
 )
 
 // FetchURL retrieves the content at url with timeouts and limited redirects
-func FetchURL(url string) (io.Reader, error) {
+func FetchURL(url string) (io.ReadCloser, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
## Summary
- return `io.ReadCloser` from `FetchURL`
- close the HTTP body in `findsomething-cli`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dc991fc408331bd4a57b7b1b049f4