### PR TITLE
Fix scanning for long lines

### DIFF
--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -131,6 +131,7 @@ func (e *Extractor) ScanReader(source string, r io.Reader) ([]Match, error) {
 		return matches, nil
 	}
 	buf := bufio.NewScanner(r)
+	buf.Buffer(make([]byte, 0, 1024), 1024*1024)
 	for buf.Scan() {
 		line := buf.Text()
 		for name, re := range e.patterns {

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -96,3 +96,29 @@ func TestAllowlistSuffix(t *testing.T) {
 		t.Fatalf("expected 0 matches, got %d", len(matches))
 	}
 }
+
+func TestScanLongLine(t *testing.T) {
+	e := NewExtractor(false)
+	longLine := strings.Repeat("a", 70*1024) + " test@example.com"
+	r := strings.NewReader(longLine)
+	matches, err := e.ScanReader("file.txt", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Pattern != "email" {
+		t.Fatalf("expected email match only, got %+v", matches)
+	}
+}
+
+func TestScanLongLineSafeMode(t *testing.T) {
+	e := NewExtractor(true)
+	longLine := strings.Repeat("a", 70*1024) + " eyJabc.def.ghi"
+	r := strings.NewReader(longLine)
+	matches, err := e.ScanReader("script.js", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Pattern != "jwt" {
+		t.Fatalf("expected jwt match only, got %+v", matches)
+	}
+}


### PR DESCRIPTION
## Summary
- enlarge Scanner buffer to 1MB in `ScanReader`
- add tests scanning lines >64KB

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dca2b8d2483318d000933aa965e4a