### PR TITLE
Add JS endpoint scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Flags:
 
 A URL, filesystem path or `-` for stdin must be provided. The program exits with status `1` when matches are found.
 
+### Endpoint scanning
+
+Package `scan` also exposes `Extractor.ScanReaderWithEndpoints` to collect
+HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
+with the pattern name `endpoint`.
+
 ## Testing
 
 ```

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -145,3 +145,25 @@ func (e *Extractor) ScanReader(source string, r io.Reader) ([]Match, error) {
 	}
 	return matches, buf.Err()
 }
+
+// ScanReaderWithEndpoints scans r like ScanReader and also extracts HTTP
+// endpoints from JavaScript sources. Endpoint matches use the pattern name
+// "endpoint".
+func (e *Extractor) ScanReaderWithEndpoints(source string, r io.Reader) ([]Match, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	matches, err := e.ScanReader(source, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	if source == "stdin" || isJSFile(source) {
+		for _, ep := range parseJSEndpoints(data) {
+			matches = append(matches, Match{Source: source, Pattern: "endpoint", Value: ep})
+		}
+	}
+	return matches, nil
+}

--- a/internal/scan/jsendpoints.go
+++ b/internal/scan/jsendpoints.go
@@ -1,0 +1,16 @@
+package scan
+
+import "regexp"
+
+// endpointRe matches HTTP endpoint strings inside quotes or backticks.
+var endpointRe = regexp.MustCompile("(?i)[\"'`](https?://[^\"'`\\s]+|/[^\"'`\\s]+)[\"'`]")
+
+// parseJSEndpoints extracts endpoints from JavaScript source data.
+func parseJSEndpoints(data []byte) []string {
+	ms := endpointRe.FindAllSubmatch(data, -1)
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, string(m[1]))
+	}
+	return out
+}

--- a/internal/scan/jsendpoints_test.go
+++ b/internal/scan/jsendpoints_test.go
@@ -1,0 +1,52 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseJSEndpoints(t *testing.T) {
+	js := `const a = "https://api.example.com/v1"; fetch('/v1/test');`
+	eps := parseJSEndpoints([]byte(js))
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(eps))
+	}
+	expected := map[string]bool{"https://api.example.com/v1": true, "/v1/test": true}
+	for _, e := range eps {
+		if !expected[e] {
+			t.Fatalf("unexpected endpoint %s", e)
+		}
+	}
+}
+
+func TestScanReaderWithEndpoints(t *testing.T) {
+	js := `fetch("https://ex.com/api"); axios.get('/v2/data');`
+	e := NewExtractor(true)
+	matches, err := e.ScanReaderWithEndpoints("script.js", strings.NewReader(js))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var endpoints []string
+	for _, m := range matches {
+		if m.Pattern == "endpoint" {
+			endpoints = append(endpoints, m.Value)
+		}
+	}
+	if len(endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(endpoints))
+	}
+}
+
+func TestScanReaderWithEndpointsNonJS(t *testing.T) {
+	js := `fetch("/should/ignore")`
+	e := NewExtractor(true)
+	matches, err := e.ScanReaderWithEndpoints("file.txt", strings.NewReader(js))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range matches {
+		if m.Pattern == "endpoint" {
+			t.Fatalf("did not expect endpoint match for non-js file")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- parse JS files for HTTP endpoints
- expose `ScanReaderWithEndpoints` to collect endpoint matches
- document new scanning ability
- test endpoint extraction logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684dcafc7aa48331aa688736b5d0e444