### PR TITLE
Add targets flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Flags:
 - `-rules` extra regex rules YAML file.
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
+- `-targets` file with additional URLs/paths to scan, one per line.
 
 ### Rule file format
 
@@ -37,7 +38,7 @@ ipv6: "[0-9a-fA-F:]+"
 ```
 See `rules-example.yaml` for a sample file.
 
-A URL, filesystem path or `-` for stdin must be provided. The program exits with status `1` when matches are found.
+A URL, filesystem path or `-` for stdin must be provided, or use `-targets` to supply multiple inputs. The program exits with status `1` when matches are found.
 
 ### Endpoint scanning
 


### PR DESCRIPTION
## Summary
- allow scanning multiple targets with `-targets`
- document the new flag

## Testing
- `go test ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1c49ec083319c827c1775ed9a3f