### PR TITLE
Add JS AST scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSMiner
 
-JSMiner provides a small command line tool for scraping JavaScript, HTML and related files to search for common patterns such as email addresses or JWT tokens. The project is written in Go and distributed under the AGPL‑3.0 license.
+JSMiner began as a small command line tool for scraping JavaScript, HTML and related files to search for common patterns such as email addresses or JWT tokens. Over time it has grown into a more full-featured utility. The latest versions parse JavaScript into an AST to detect values stored in variables or built from string concatenation. The project is written in Go and distributed under the AGPL‑3.0 license.
 
 ## Building
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module jsminer
 
 go 1.23.8
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+    gopkg.in/yaml.v3 v3.0.1
+    github.com/tdewolff/parse/v2 v2.7.1
+)

--- a/internal/scan/extractor_ast_test.go
+++ b/internal/scan/extractor_ast_test.go
@@ -1,0 +1,30 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanReaderASTVar(t *testing.T) {
+	src := `const t = "eyJabc.def.ghi"`
+	e := NewExtractor(true)
+	matches, err := e.ScanReaderAST("script.js", strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Pattern != "jwt" {
+		t.Fatalf("expected jwt match, got %+v", matches)
+	}
+}
+
+func TestScanReaderASTConcat(t *testing.T) {
+	src := `const t = "eyJabc." + "def.ghi"`
+	e := NewExtractor(true)
+	matches, err := e.ScanReaderAST("script.js", strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Pattern != "jwt" {
+		t.Fatalf("expected jwt match, got %+v", matches)
+	}
+}

--- a/internal/scan/jsast/jsast.go
+++ b/internal/scan/jsast/jsast.go
@@ -1,0 +1,78 @@
+package jsast
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+
+	"github.com/tdewolff/parse/v2"
+	"github.com/tdewolff/parse/v2/js"
+)
+
+// ExtractValues parses JavaScript source and returns string values found in
+// string literals, template strings and simple variable assignments.
+func ExtractValues(data []byte) []string {
+	l := js.NewLexer(parse.NewInputBytes(data))
+	var values []string
+
+	var expectAssign bool
+	var assignActive bool
+	var buf []string
+
+	for {
+		tt, lit := l.Next()
+		if tt == js.ErrorToken {
+			break
+		}
+		switch tt {
+		case js.StringToken:
+			s, _ := strconv.Unquote(string(lit))
+			if assignActive {
+				buf = append(buf, s)
+			}
+			values = append(values, s)
+		case js.TemplateToken:
+			if assignActive {
+				buf = append(buf, string(lit))
+			}
+			values = append(values, string(lit))
+		case js.IdentifierToken:
+			expectAssign = true
+		case js.KeywordToken:
+			if bytes.Equal(lit, []byte("var")) || bytes.Equal(lit, []byte("let")) || bytes.Equal(lit, []byte("const")) {
+				expectAssign = true
+			} else {
+				expectAssign = false
+			}
+		case js.PunctuatorToken:
+			if expectAssign && bytes.Equal(lit, []byte("=")) {
+				assignActive = true
+				buf = nil
+				expectAssign = false
+			} else if assignActive {
+				if !bytes.Equal(lit, []byte("+")) {
+					assignActive = false
+					if len(buf) > 0 {
+						values = append(values, strings.Join(buf, ""))
+					}
+					buf = nil
+				}
+			} else {
+				expectAssign = false
+			}
+		default:
+			if assignActive {
+				assignActive = false
+				if len(buf) > 0 {
+					values = append(values, strings.Join(buf, ""))
+				}
+				buf = nil
+			}
+			expectAssign = false
+		}
+	}
+	if assignActive && len(buf) > 0 {
+		values = append(values, strings.Join(buf, ""))
+	}
+	return values
+}

--- a/internal/scan/jsast/jsast_test.go
+++ b/internal/scan/jsast/jsast_test.go
@@ -1,0 +1,14 @@
+package jsast
+
+import (
+	"testing"
+)
+
+// basic sanity test for ExtractValues using simple JS string
+func TestExtractValues(t *testing.T) {
+	js := []byte(`const a = "foo";`)
+	vals := ExtractValues(js)
+	if len(vals) == 0 {
+		t.Fatal("expected values")
+	}
+}


### PR DESCRIPTION
## Summary
- parse JavaScript with new `internal/scan/jsast` package
- expose `Extractor.ScanReaderAST` for AST-based secret detection
- add unit tests for AST scanning
- clarify in README that the project has grown beyond a small CLI tool

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: missing go.sum entry)*
- `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684dd74c8f48833181bcbec53ad64ec3