### PR TITLE
Introduce plugin-based rule system with severity levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Flags:
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.
+- `-plugins` comma-separated list of Go plugins providing custom rules.
 
 ### Rule file format
 
@@ -39,12 +40,29 @@ ipv6: "[0-9a-fA-F:]+"
 See `examples/rules.yaml` for a sample file.
 
 A URL, filesystem path or `-` for stdin must be provided, or use `-targets` to supply multiple inputs. The program exits with status `1` when matches are found.
+Each match also includes a `severity` level.
 
 ### Endpoint scanning
 
 Package `scan` also exposes `Extractor.ScanReaderWithEndpoints` to collect
 HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
 with the pattern name `endpoint`.
+
+### Plugins
+
+Additional rules can be compiled as Go plugins. Build the plugin with
+
+```
+go build -buildmode=plugin -o entropy.so ./examples/entropy
+```
+
+Load it at runtime with the `-plugins` flag:
+
+```
+jsminer -plugins entropy.so file.js
+```
+
+See `examples/entropy` for a simple entropy based rule.
 
 ## Testing
 

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"plugin"
 	"strings"
 
 	"jsminer/internal/output"
@@ -22,6 +23,7 @@ func main() {
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
 	targetsFile := flag.String("targets", "", "file with list of targets")
+	pluginsFlag := flag.String("plugins", "", "comma-separated plugin files")
 	flag.Parse()
 
 	if flag.NArg() < 1 && *targetsFile == "" {
@@ -50,6 +52,18 @@ func main() {
 	}
 	if flag.NArg() >= 1 {
 		targets = append(targets, flag.Arg(0))
+	}
+
+	if *pluginsFlag != "" {
+		for _, pl := range strings.Split(*pluginsFlag, ",") {
+			pl = strings.TrimSpace(pl)
+			if pl == "" {
+				continue
+			}
+			if _, err := plugin.Open(pl); err != nil {
+				log.Fatal(err)
+			}
+		}
 	}
 
 	extractor := scan.NewExtractor(*safe)

--- a/examples/entropy/entropy.go
+++ b/examples/entropy/entropy.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"math"
+	"regexp"
+
+	"jsminer/internal/scan"
+)
+
+// EntropyRule flags strings with high Shannon entropy.
+type EntropyRule struct{}
+
+func (EntropyRule) MatchName() string { return "entropy" }
+
+func entropy(s string) float64 {
+	freq := make(map[rune]float64)
+	for _, r := range s {
+		freq[r]++
+	}
+	var ent float64
+	for _, c := range freq {
+		p := c / float64(len(s))
+		ent -= p * math.Log2(p)
+	}
+	return ent
+}
+
+var candidate = regexp.MustCompile(`[A-Za-z0-9+/=]{20,}`)
+
+func (EntropyRule) Find(data []byte) []scan.Match {
+	var out []scan.Match
+	for _, b := range candidate.FindAll(data, -1) {
+		s := string(b)
+		if entropy(s) >= 4.5 {
+			out = append(out, scan.Match{Pattern: "entropy", Value: s, Severity: "high"})
+		}
+	}
+	return out
+}
+
+func init() {
+	scan.RegisterRule(EntropyRule{})
+}

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -23,7 +23,7 @@ func NewPrinter(format string, banner bool) *Printer {
 func (p *Printer) Print(w io.Writer, matches []scan.Match) error {
 	if p.format == "pretty" {
 		for _, m := range matches {
-			fmt.Fprintf(w, "%s: [%s] %s\n", m.Source, m.Pattern, m.Value)
+			fmt.Fprintf(w, "%s: [%s] (%s) %s\n", m.Source, m.Pattern, m.Severity, m.Value)
 		}
 		return nil
 	}

--- a/internal/scan/rule.go
+++ b/internal/scan/rule.go
@@ -1,0 +1,34 @@
+package scan
+
+import "regexp"
+
+// Rule defines an interface for matchers used by Extractor.
+type Rule interface {
+	MatchName() string
+	Find(data []byte) []Match
+}
+
+// RegexRule implements Rule using a regular expression.
+type RegexRule struct {
+	Name     string
+	RE       *regexp.Regexp
+	Severity string
+}
+
+func (r RegexRule) MatchName() string { return r.Name }
+
+func (r RegexRule) Find(data []byte) []Match {
+	var matches []Match
+	for _, m := range r.RE.FindAll(data, -1) {
+		matches = append(matches, Match{Pattern: r.Name, Value: string(m), Severity: r.Severity})
+	}
+	return matches
+}
+
+var registeredRules []Rule
+
+// RegisterRule adds r to the global rule registry. Plugin init functions
+// should call this to make their rules available.
+func RegisterRule(r Rule) { registeredRules = append(registeredRules, r) }
+
+func getRegisteredRules() []Rule { return registeredRules }


### PR DESCRIPTION
## Summary
- add a `Rule` interface and regex rule implementation
- allow plugins to register rules
- support a `-plugins` CLI option
- add severity field on matches and show it in output
- provide example entropy rule plugin
- document plugin usage in README

## Testing
- `go test ./...` *(fails: missing module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684dd943003c83319239fe45cb5eedd3