### PR TITLE
Add default power rules and path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Flags:
 - `-targets` file with additional URLs/paths to scan, one per line.
 - `-plugins` comma-separated list of Go plugins providing custom rules.
 
+The binary includes a small set of **power rules** enabled by default. These
+rules detect common items such as phone numbers, IPv6 addresses and generic
+file paths. Supplying a file with `-rules` adds to this default set.
+
 ### Rule file format
 
 The file supplied via `-rules` must be a YAML mapping where each key is the
@@ -36,6 +40,7 @@ pattern name and the value is a Go regular expression. The file is parsed using
 ```yaml
 phone: "\\d{3}-\\d{3}-\\d{4}"
 ipv6: "[0-9a-fA-F:]+"
+path: "(?:/[A-Za-z0-9._-]+)+|[A-Za-z]:\\(?:[^\\\s]+\\)*[^\\\s]+"
 ```
 See `examples/rules.yaml` for a sample file.
 

--- a/examples/rules.yaml
+++ b/examples/rules.yaml
@@ -2,3 +2,4 @@
 # Map pattern names to Go regular expressions
 phone: "\\d{3}-\\d{3}-\\d{4}"
 ipv6: "[0-9a-fA-F:]+"
+path: "(?:/[A-Za-z0-9._-]+)+|[A-Za-z]:\\(?:[^\\\s]+\\)*[^\\\s]+"

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -44,10 +44,21 @@ var defaultPatterns = map[string]string{
 	"bearer":     `(?i)bearer\s+[A-Za-z0-9._-]{10,}`,
 }
 
+// powerPatterns provide additional regexes enabled by default.
+var powerPatterns = map[string]string{
+	"phone": `\d{3}-\d{3}-\d{4}`,
+	"ipv6":  `[0-9a-fA-F:]+`,
+	// crude file path detection for Unix and Windows paths
+	"path": `(?:/[A-Za-z0-9._-]+)+|[A-Za-z]:\\\\(?:[^\\\\\s]+\\\\)*[^\\\\\s]+`,
+}
+
 // NewExtractor creates an Extractor
 func NewExtractor(safe bool) *Extractor {
 	e := &Extractor{safeMode: safe}
 	for name, pat := range defaultPatterns {
+		e.rules = append(e.rules, RegexRule{Name: name, RE: regexp.MustCompile(pat), Severity: "info"})
+	}
+	for name, pat := range powerPatterns {
 		e.rules = append(e.rules, RegexRule{Name: name, RE: regexp.MustCompile(pat), Severity: "info"})
 	}
 	e.rules = append(e.rules, getRegisteredRules()...)

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -165,3 +165,21 @@ func TestLoadRulesFileInvalid(t *testing.T) {
 		t.Fatal("expected error for invalid YAML")
 	}
 }
+
+func TestPowerRulesDefault(t *testing.T) {
+	e := NewExtractor(false)
+	r := strings.NewReader("/tmp/data 2001:db8::1 123-456-7890")
+	matches, err := e.ScanReader("file.txt", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, m := range matches {
+		found[m.Pattern] = true
+	}
+	for _, p := range []string{"path", "ipv6", "phone"} {
+		if !found[p] {
+			t.Fatalf("expected match for %s", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add examples rule to detect paths
- implement built-in power rules (phone, ipv6, path) and load by default
- document power rules in README
- test default power rule behaviour

## Testing
- `go test ./...` *(fails: missing go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_684ddbaeb3b0833182f0dd2c5dac78f1