### PR TITLE
Add endpoint flag usage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ This produces a binary named `jsminer`.
 
 ## Usage
 
+``` 
+jsminer [flags] [URL|PATH|-] 
 ```
-jsminer [URL|PATH|-] [flags]
-```
+
+Flags must appear before the input path or URL.
 
 Flags:
 
@@ -22,6 +24,7 @@ Flags:
 - `-safe` safe mode - ignore non-JS files and patterns that aren't JavaScript specific (default `true`).
 - `-allow` allowlist file. Sources whose names end with any suffix listed in this file are ignored.
 - `-rules` extra regex rules YAML file.
+- `-endpoints` also extract HTTP endpoints from JavaScript
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.
@@ -52,6 +55,12 @@ Each match also includes a `severity` level.
 Package `scan` also exposes `Extractor.ScanReaderWithEndpoints` to collect
 HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
 with the pattern name `endpoint`.
+
+Example usage:
+
+```bash
+jsminer -format pretty -endpoints app.js
+```
 
 ### Plugins
 

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -20,6 +20,7 @@ func main() {
 	safe := flag.Bool("safe", true, "safe mode - only scan JS")
 	allowFile := flag.String("allow", "", "allowlist file")
 	rulesFile := flag.String("rules", "", "extra regex rules YAML")
+	endpoints := flag.Bool("endpoints", false, "extract HTTP endpoints from JavaScript")
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
 	targetsFile := flag.String("targets", "", "file with list of targets")
@@ -27,7 +28,7 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() < 1 && *targetsFile == "" {
-		fmt.Fprintln(os.Stderr, "usage: jsminer [URL|PATH|-] [flags]")
+		fmt.Fprintln(os.Stderr, "usage: jsminer [flags] [URL|PATH|-]")
 		os.Exit(2)
 	}
 
@@ -103,7 +104,13 @@ func main() {
 		}
 
 		input := bufio.NewReader(reader)
-		ms, err := extractor.ScanReader(base, input)
+		var ms []scan.Match
+		var err error
+		if *endpoints {
+			ms, err = extractor.ScanReaderWithEndpoints(base, input)
+		} else {
+			ms, err = extractor.ScanReader(base, input)
+		}
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
- fix usage string to show flag order before URL
- document example command for endpoint scanning

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ddf3c46808331982c4ce1a0c92e9a