### PR TITLE
Add user agent header to FetchURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSMiner
 
-JSMiner began as a small command line tool for scraping JavaScript, HTML and related files to search for common patterns such as email addresses or JWT tokens. Over time it has grown into a more full-featured utility. The latest versions parse JavaScript into an AST to detect values stored in variables or built from string concatenation. The project is written in Go and distributed under the AGPL‑3.0 license.
+JSMiner began as a small command line tool for scraping JavaScript, HTML and related files to search for common patterns such as email addresses or JWT tokens. Over time it has grown into a more full-featured utility. The latest versions parse JavaScript into an AST to detect values stored in variables or built from string concatenation. HTTP requests now include a browser-style User-Agent header so more sites will serve their JavaScript correctly. The project is written in Go and distributed under the AGPL‑3.0 license.
 
 ## Building
 

--- a/internal/scan/fetch.go
+++ b/internal/scan/fetch.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+
 // FetchURL retrieves the content at url with timeouts and limited redirects
 func FetchURL(url string) (io.ReadCloser, error) {
 	client := http.Client{
@@ -17,7 +19,13 @@ func FetchURL(url string) (io.ReadCloser, error) {
 			return nil
 		},
 	}
-	resp, err := client.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", defaultUserAgent)
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scan/fetch_test.go
+++ b/internal/scan/fetch_test.go
@@ -1,0 +1,28 @@
+package scan
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Test that FetchURL sets the User-Agent header on requests
+func TestFetchURLSetsUserAgent(t *testing.T) {
+	var ua string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua = r.Header.Get("User-Agent")
+		io.WriteString(w, "ok")
+	}))
+	defer ts.Close()
+
+	rc, err := FetchURL(ts.URL)
+	if err != nil {
+		t.Fatalf("FetchURL returned error: %v", err)
+	}
+	rc.Close()
+
+	if ua != defaultUserAgent {
+		t.Fatalf("expected User-Agent %q, got %q", defaultUserAgent, ua)
+	}
+}


### PR DESCRIPTION
## Summary
- set a default browser-style User-Agent header for HTTP requests
- document the new behavior in the README
- test that FetchURL includes the header

## Testing
- `go test ./...`
- `go run ./cmd/testfetch` (manual check removed after testing)


------
https://chatgpt.com/codex/tasks/task_e_684de8a7bfd48331aebb839917e1d42b