### PR TITLE
Add conditional source field in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See `examples/rules.yaml` for a sample file.
 
 A URL, filesystem path or `-` for stdin must be provided, or use `-targets` to supply multiple inputs. The program exits with status `1` when matches are found.
 Each match also includes a `severity` level.
+When scanning a single input, the JSON output omits the `source` field.
 
 ### Endpoint scanning
 

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -170,7 +170,8 @@ func main() {
 		out = f
 	}
 
-	printer := output.NewPrinter(*format, !*quiet)
+	showSource := len(targets) > 1
+	printer := output.NewPrinter(*format, !*quiet, showSource)
 	if err := printer.Print(out, allMatches); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -10,23 +10,43 @@ import (
 
 // Printer handles output rendering
 type Printer struct {
-	format string
-	banner bool
+	format     string
+	banner     bool
+	showSource bool
 }
 
 // NewPrinter creates a printer
-func NewPrinter(format string, banner bool) *Printer {
-	return &Printer{format: format, banner: banner}
+func NewPrinter(format string, banner bool, showSource bool) *Printer {
+	return &Printer{format: format, banner: banner, showSource: showSource}
 }
 
 // Print writes matches to w
 func (p *Printer) Print(w io.Writer, matches []scan.Match) error {
 	if p.format == "pretty" {
 		for _, m := range matches {
-			fmt.Fprintf(w, "%s: [%s] (%s) %s\n", m.Source, m.Pattern, m.Severity, m.Value)
+			if p.showSource {
+				fmt.Fprintf(w, "%s: [%s] (%s) %s\n", m.Source, m.Pattern, m.Severity, m.Value)
+			} else {
+				fmt.Fprintf(w, "[%s] (%s) %s\n", m.Pattern, m.Severity, m.Value)
+			}
 		}
 		return nil
 	}
+
+	type outMatch struct {
+		Source   string `json:"source,omitempty"`
+		Pattern  string `json:"pattern"`
+		Value    string `json:"value"`
+		Severity string `json:"severity"`
+	}
+	out := make([]outMatch, 0, len(matches))
+	for _, m := range matches {
+		om := outMatch{Pattern: m.Pattern, Value: m.Value, Severity: m.Severity}
+		if p.showSource {
+			om.Source = m.Source
+		}
+		out = append(out, om)
+	}
 	enc := json.NewEncoder(w)
-	return enc.Encode(matches)
+	return enc.Encode(out)
 }


### PR DESCRIPTION
## Summary
- make Printer aware of single vs. multiple inputs
- omit the `source` field from JSON/pretty output when scanning a single input
- mention this behavior in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684debb3d9188331aa3b4e3eefc91589