### PR TITLE
Distinguish URL and path endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ When scanning a single input, the JSON output omits the `source` field.
 
 Package `scan` also exposes `Extractor.ScanReaderWithEndpoints` to collect
 HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
-with the pattern name `endpoint`. In addition to absolute URLs, the extractor
-recognizes protocol-relative references and relative paths beginning with
-`./` or `../`.
+with the pattern name `endpoint_url` for absolute URLs and `endpoint_path` for
+relative paths. The extractor recognizes protocol-relative references and
+relative paths beginning with `./` or `../`.
 
 ### Plugins
 

--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -189,7 +189,7 @@ func (e *Extractor) ScanReader(source string, r io.Reader) ([]Match, error) {
 
 // ScanReaderWithEndpoints scans r like ScanReader and also extracts HTTP
 // endpoints from JavaScript sources. Endpoint matches use the pattern name
-// "endpoint".
+// "endpoint_url" for absolute URLs and "endpoint_path" for relative paths.
 func (e *Extractor) ScanReaderWithEndpoints(source string, r io.Reader) ([]Match, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -203,7 +203,11 @@ func (e *Extractor) ScanReaderWithEndpoints(source string, r io.Reader) ([]Match
 
 	if source == "stdin" || isJSFile(source) {
 		for _, ep := range parseJSEndpoints(data) {
-			matches = append(matches, Match{Source: source, Pattern: "endpoint", Value: ep, Severity: "info"})
+			p := "endpoint_path"
+			if ep.IsURL {
+				p = "endpoint_url"
+			}
+			matches = append(matches, Match{Source: source, Pattern: p, Value: ep.Value, Severity: "info"})
 		}
 	}
 	return matches, nil


### PR DESCRIPTION
## Summary
- detect whether extracted JavaScript endpoints are URLs or paths
- expose endpoint matches as `endpoint_url` or `endpoint_path`
- update README documentation
- extend unit tests for new behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ded3cd0d883319a58002572f77cb2