### PR TITLE
Improve sensitive info detection

### DIFF
--- a/internal/scan/extractor.go
+++ b/internal/scan/extractor.go
@@ -69,6 +69,12 @@ var defaultPatterns = map[string]string{
 	"aws_secret": `(?i)aws_secret_access_key\s*[:=]\s*[A-Za-z0-9/+=]{40}`,
 	"google_api": `AIza[0-9A-Za-z-_]{35}`,
 	"bearer":     `(?i)bearer\s+[A-Za-z0-9._-]{10,}`,
+	// generic API key style values
+	"api_key": `(?i)api[-_]?key\s*[:=]\s*["']?[A-Za-z0-9-_]{16,}`,
+	// generic access or auth token values
+	"token": `(?i)(?:access|auth)?_?token\s*[:=]\s*["']?[A-Za-z0-9-_]{10,}`,
+	// passwords with at least 4 non-space characters
+	"password": `(?i)password\s*[:=]\s*["']?\S{4,}`,
 }
 
 // powerPatterns provide additional regexes enabled by default.

--- a/internal/scan/extractor_test.go
+++ b/internal/scan/extractor_test.go
@@ -183,3 +183,36 @@ func TestPowerRulesDefault(t *testing.T) {
 		}
 	}
 }
+
+func TestSensitiveDefaults(t *testing.T) {
+	e := NewExtractor(false)
+	r := strings.NewReader(`password="secretpass" api_key=ABCDEF1234567890 token=abcdef123456`)
+	matches, err := e.ScanReader("file.txt", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("expected 3 matches, got %d", len(matches))
+	}
+	found := map[string]bool{}
+	for _, m := range matches {
+		found[m.Pattern] = true
+	}
+	for _, p := range []string{"password", "api_key", "token"} {
+		if !found[p] {
+			t.Fatalf("expected match for %s", p)
+		}
+	}
+}
+
+func TestShortPasswordIgnored(t *testing.T) {
+	e := NewExtractor(false)
+	r := strings.NewReader(`password:x api_key=short token=abc`)
+	matches, err := e.ScanReader("file.txt", r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+}


### PR DESCRIPTION
## Summary
- enhance default regex patterns with basic API key, token and password rules
- test new sensitive information patterns and verify short values aren't flagged

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684df1695abc833195eff10221f13736