### PR TITLE
Add banner with attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+```
+       _______ __  ____                
+      / / ___//  |/  (_)___  ___  _____
+ __  / /\__ \/ /|_/ / / __ \/ _ \/ ___/
+/ /_/ /___/ / /  / / / / / /  __/ /    
+\____//____/_/  /_/_/_/ /_/\___/_/     
+                                       
+by Tevger Xanê (Tavgar El Ahmed)
+Bijî Kurdistan
+```
 # JSMiner
 
 JSMiner began as a small command line tool for scraping JavaScript, HTML and related files to search for common patterns such as email addresses or JWT tokens. Over time it has grown into a more full-featured utility. The latest versions parse JavaScript into an AST to detect values stored in variables or built from string concatenation. HTTP requests now include a browser-style User-Agent header so more sites will serve their JavaScript correctly. The project is written in Go and distributed under the AGPL‑3.0 license.

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tavgar/JSMiner/internal/scan"
 )
 
+const version = "0.01v"
+
 func main() {
 	format := flag.String("format", "json", "output format: pretty or json")
 	safe := flag.Bool("safe", true, "safe mode - only scan JS")
@@ -163,7 +165,7 @@ func main() {
 	}
 
 	showSource := len(targets) > 1
-	printer := output.NewPrinter(*format, !*quiet, showSource)
+	printer := output.NewPrinter(*format, !*quiet, showSource, version)
 	if err := printer.Print(out, allMatches); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/output/banner.go
+++ b/internal/output/banner.go
@@ -1,0 +1,17 @@
+package output
+
+import "fmt"
+
+func Banner(version string) string {
+	red := "\x1b[31m"
+	green := "\x1b[32m"
+	yellow := "\x1b[33m"
+	reset := "\x1b[0m"
+	art := `       _______ __  ____
+      / / ___//  |/  (_)___  ___  _____
+ __  / /\__ \/ /|_/ / / __ \/ _ \/ ___/
+/ /_/ /___/ / /  / / / / / /  __/ /
+\____//____/_/  /_/_/_/ /_/\___/_/`
+	coloredSlogan := fmt.Sprintf("%sBij\u00ee%s %s\u2605%s %sKurdistan%s", red, reset, yellow, reset, green, reset)
+	return fmt.Sprintf("%s\n\nby Tevger Xan\u00ea (Tavgar El Ahmed)\n%s\nversion %s\n", art, coloredSlogan, version)
+}

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -13,15 +13,20 @@ type Printer struct {
 	format     string
 	banner     bool
 	showSource bool
+	version    string
 }
 
 // NewPrinter creates a printer
-func NewPrinter(format string, banner bool, showSource bool) *Printer {
-	return &Printer{format: format, banner: banner, showSource: showSource}
+func NewPrinter(format string, banner bool, showSource bool, version string) *Printer {
+	return &Printer{format: format, banner: banner, showSource: showSource, version: version}
 }
 
 // Print writes matches to w
 func (p *Printer) Print(w io.Writer, matches []scan.Match) error {
+	if p.banner {
+		fmt.Fprintln(w, Banner(p.version))
+	}
+
 	if p.format == "pretty" {
 		for _, m := range matches {
 			if p.showSource {


### PR DESCRIPTION
## Summary
- add a banner made with `figlet`
- include credit line and slogan
- show banner on startup with colors and version 0.01v

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684eb5c6cc84833193099a0dec57e87f