### PR TITLE
Add external flag for cross-domain scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flags:
 - `-allow` allowlist file. Sources whose names end with any suffix listed in this file are ignored.
 - `-rules` extra regex rules YAML file.
 - `-endpoints` also extract HTTP endpoints from JavaScript
+- `-external` follow external scripts and imports when scanning URLs
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.
@@ -74,6 +75,8 @@ HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
 with the pattern name `endpoint_url` for absolute URLs and `endpoint_path` for
 relative paths. The extractor recognizes protocol-relative references and
 relative paths beginning with `./` or `../`.
+Use the `-external` flag when scanning a URL to also process scripts and
+imports hosted on other domains.
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Flags:
 - `-allow` allowlist file. Sources whose names end with any suffix listed in this file are ignored.
 - `-rules` extra regex rules YAML file.
 - `-endpoints` also extract HTTP endpoints from JavaScript
-- `-external` follow external scripts and imports when scanning URLs
+- `-external` follow external scripts and imports (default `true`)
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.
@@ -75,8 +75,7 @@ HTTP endpoint strings inside JavaScript sources. Endpoint matches are returned
 with the pattern name `endpoint_url` for absolute URLs and `endpoint_path` for
 relative paths. The extractor recognizes protocol-relative references and
 relative paths beginning with `./` or `../`.
-Use the `-external` flag when scanning a URL to also process scripts and
-imports hosted on other domains.
+Cross-domain scripts and imports are followed by default. Pass `-external=false` to restrict scanning to the same domain.
 
 ### Plugins
 

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -22,6 +22,7 @@ func main() {
 	allowFile := flag.String("allow", "", "allowlist file")
 	rulesFile := flag.String("rules", "", "extra regex rules YAML")
 	endpoints := flag.Bool("endpoints", false, "extract HTTP endpoints from JavaScript")
+	external := flag.Bool("external", false, "follow external scripts and imports")
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
 	targetsFile := flag.String("targets", "", "file with list of targets")
@@ -41,6 +42,8 @@ func main() {
 		switch name {
 		case "endpoints":
 			*endpoints = true
+		case "external":
+			*external = true
 		case "safe":
 			*safe = true
 		case "quiet":
@@ -134,7 +137,7 @@ func main() {
 				ms, err = extractor.ScanReader("stdin", reader)
 			}
 		} else if isURL(target) {
-			ms, err = extractor.ScanURL(target, *endpoints)
+			ms, err = extractor.ScanURL(target, *endpoints, *external)
 		} else {
 			f, err2 := os.Open(target)
 			if err2 != nil {

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"plugin"
+	"strconv"
 	"strings"
 
 	"github.com/tavgar/JSMiner/internal/output"
@@ -22,7 +23,7 @@ func main() {
 	allowFile := flag.String("allow", "", "allowlist file")
 	rulesFile := flag.String("rules", "", "extra regex rules YAML")
 	endpoints := flag.Bool("endpoints", false, "extract HTTP endpoints from JavaScript")
-	external := flag.Bool("external", false, "follow external scripts and imports")
+	external := flag.Bool("external", true, "follow external scripts and imports")
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
 	targetsFile := flag.String("targets", "", "file with list of targets")
@@ -39,11 +40,24 @@ func main() {
 			continue
 		}
 		name := strings.TrimLeft(a, "-")
+		parts := strings.SplitN(name, "=", 2)
+		name = parts[0]
 		switch name {
 		case "endpoints":
 			*endpoints = true
 		case "external":
-			*external = true
+			val := "true"
+			if len(parts) == 2 {
+				val = parts[1]
+			} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				val = args[i+1]
+				i++
+			}
+			if b, err := strconv.ParseBool(val); err == nil {
+				*external = b
+			} else {
+				*external = true
+			}
 		case "safe":
 			*safe = true
 		case "quiet":

--- a/internal/scan/urlscan.go
+++ b/internal/scan/urlscan.go
@@ -90,9 +90,7 @@ func isHTMLContent(urlStr, ct string) bool {
 }
 
 // ScanURL scans urlStr and any discovered script or import references.
-// By default only same-domain resources are followed, but when the
-// external parameter is true, cross-domain scripts and imports are also
-// processed. JavaScript files are scanned using the configured rules.
+// Cross-domain resources are followed by default. Set external to false to restrict scanning to the same domain. JavaScript files are scanned using the configured rules.
 func (e *Extractor) ScanURL(urlStr string, endpoints bool, external bool) ([]Match, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
@@ -104,8 +102,8 @@ func (e *Extractor) ScanURL(urlStr string, endpoints bool, external bool) ([]Mat
 
 // scanURL performs the recursive scanning used by ScanURL. The baseHost
 // parameter indicates the host of the initial URL. The visited map tracks
-// already processed URLs to avoid loops. When external is true, resources
-// from other domains are allowed.
+// already processed URLs to avoid loops. When external is false, only resources
+// from the same domain are processed.
 func (e *Extractor) scanURL(urlStr, baseHost string, endpoints bool, visited map[string]struct{}, external bool) ([]Match, error) {
 	if _, ok := visited[urlStr]; ok {
 		return nil, nil

--- a/internal/scan/urlscan_test.go
+++ b/internal/scan/urlscan_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,43 @@ func TestScanURL(t *testing.T) {
 	}
 	if !foundJWT || !foundEndpoint {
 		t.Fatalf("missing expected matches: jwt=%v endpoint=%v", foundJWT, foundEndpoint)
+	}
+}
+
+// Test that ScanURL follows scripts from other hosts when external scanning is enabled.
+func TestScanURLExternal(t *testing.T) {
+	muxJS := http.NewServeMux()
+	muxJS.HandleFunc("/ext.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		io.WriteString(w, "fetch('https://api.example.com/v2');")
+	})
+	tsJS := httptest.NewServer(muxJS)
+	defer tsJS.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, `<html><script src="`+tsJS.URL+`/ext.js"></script></html>`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	e := NewExtractor(true)
+	matches, err := e.ScanURL(ts.URL, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected matches, got none")
+	}
+	found := false
+	for _, m := range matches {
+		if m.Pattern == "endpoint_url" && strings.Contains(m.Value, "api.example.com") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected to find endpoint from external script")
 	}
 }

--- a/internal/scan/urlscan_test.go
+++ b/internal/scan/urlscan_test.go
@@ -27,7 +27,7 @@ func TestScanURL(t *testing.T) {
 	defer ts.Close()
 
 	e := NewExtractor(true)
-	matches, err := e.ScanURL(ts.URL, true)
+	matches, err := e.ScanURL(ts.URL, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- add `-external` flag to follow cross-domain scripts and imports
- update scanning logic to allow external resources
- document the new option in README
- adjust tests for the updated API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ec40994c88331bf9305f15f86adfb