### PR TITLE
Enable render mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Flags:
 - `-endpoints` return only HTTP endpoints (default includes all matches)
 - `-posts` return HTTP POST request endpoints with any parameters
 - `-external` follow external scripts and imports (default `true`)
-- `-render` render pages with headless Chrome (Chrome/Chromium must be installed)
+- `-render` render pages with headless Chrome (default `true`, set `-render=false` to disable; Chrome/Chromium must be installed)
 - `-output` write output to file instead of stdout.
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -25,7 +25,7 @@ func main() {
 	endpoints := flag.Bool("endpoints", false, "only return HTTP endpoints")
 	posts := flag.Bool("posts", false, "only return HTTP POST request endpoints")
 	external := flag.Bool("external", true, "follow external scripts and imports")
-	render := flag.Bool("render", false, "render pages in headless Chrome")
+	render := flag.Bool("render", true, "render pages in headless Chrome")
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
 	targetsFile := flag.String("targets", "", "file with list of targets")
@@ -50,7 +50,18 @@ func main() {
 		case "posts":
 			*posts = true
 		case "render":
-			*render = true
+			val := "true"
+			if len(parts) == 2 {
+				val = parts[1]
+			} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				val = args[i+1]
+				i++
+			}
+			if b, err := strconv.ParseBool(val); err == nil {
+				*render = b
+			} else {
+				*render = true
+			}
 		case "external":
 			val := "true"
 			if len(parts) == 2 {


### PR DESCRIPTION
## Summary
- turn on `-render` by default and allow `-render=false`
- document new default in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b466c49288331a483bd802c8399a1