### PR TITLE
Add custom header flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Flags:
 - `-quiet` suppress startup banner.
 - `-targets` file with additional URLs/paths to scan, one per line.
 - `-plugins` comma-separated list of Go plugins providing custom rules.
+- `-header` HTTP header in `Key: Value` form. May be specified multiple times.
 
 Using `-render` requires Chrome or Chromium to be installed on your system.
 

--- a/internal/scan/fetch.go
+++ b/internal/scan/fetch.go
@@ -3,10 +3,43 @@ package scan
 import (
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
 const defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+
+// extraHeaders holds additional headers specified by the user via CLI flags.
+// It is modified through SetExtraHeaders and read by request helper functions.
+var extraHeaders = make(http.Header)
+
+// SetExtraHeaders replaces the global extra headers used for all outgoing
+// HTTP requests. It makes a copy of the provided header map.
+func SetExtraHeaders(h http.Header) {
+	extraHeaders = make(http.Header)
+	for k, vals := range h {
+		for _, v := range vals {
+			extraHeaders.Add(k, v)
+		}
+	}
+}
+
+// applyHeaders sets the default User-Agent and any extra headers on req.
+func applyHeaders(req *http.Request) {
+	ua := defaultUserAgent
+	if vals := extraHeaders.Values("User-Agent"); len(vals) > 0 {
+		ua = vals[len(vals)-1]
+	}
+	req.Header.Set("User-Agent", ua)
+	for k, vals := range extraHeaders {
+		if strings.EqualFold(k, "User-Agent") {
+			continue
+		}
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+}
 
 // FetchURL retrieves the content at url with timeouts and limited redirects
 func FetchURL(url string) (io.ReadCloser, error) {
@@ -23,7 +56,7 @@ func FetchURL(url string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", defaultUserAgent)
+	applyHeaders(req)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/scan/fetch_test.go
+++ b/internal/scan/fetch_test.go
@@ -16,6 +16,7 @@ func TestFetchURLSetsUserAgent(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	SetExtraHeaders(nil)
 	rc, err := FetchURL(ts.URL)
 	if err != nil {
 		t.Fatalf("FetchURL returned error: %v", err)
@@ -24,5 +25,28 @@ func TestFetchURLSetsUserAgent(t *testing.T) {
 
 	if ua != defaultUserAgent {
 		t.Fatalf("expected User-Agent %q, got %q", defaultUserAgent, ua)
+	}
+}
+
+// Test that FetchURL uses extra headers provided via SetExtraHeaders
+func TestFetchURLExtraHeaders(t *testing.T) {
+	var hv string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hv = r.Header.Get("X-Test")
+		io.WriteString(w, "ok")
+	}))
+	defer ts.Close()
+
+	h := http.Header{}
+	h.Set("X-Test", "yes")
+	SetExtraHeaders(h)
+	rc, err := FetchURL(ts.URL)
+	if err != nil {
+		t.Fatalf("FetchURL returned error: %v", err)
+	}
+	rc.Close()
+
+	if hv != "yes" {
+		t.Fatalf("expected header X-Test yes, got %q", hv)
 	}
 }

--- a/internal/scan/urlscan.go
+++ b/internal/scan/urlscan.go
@@ -27,7 +27,7 @@ func fetchURLResponse(u string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", defaultUserAgent)
+	applyHeaders(req)
 	return client.Do(req)
 }
 


### PR DESCRIPTION
## Summary
- add `-header` CLI flag to specify extra HTTP request headers
- implement header parsing in `jsminer` command
- store headers in scan package and apply to requests
- support headers in Chrome rendering
- document `-header` option in README
- test custom header usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685dc32271f88331a1fcfb312592eee6