### PR TITLE
Add configurable timeout flag for render wait time

### DIFF
--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -41,6 +41,7 @@ func main() {
 	targetsFile := flag.String("targets", "", "file with list of targets")
 	pluginsFlag := flag.String("plugins", "", "comma-separated plugin files")
 	showSourceFlag := flag.Bool("show-source", false, "show source of each record (auto-enabled for multiple targets)")
+	timeout := flag.Int("timeout", 8, "wait time in seconds for dynamic content to load when rendering pages (default: 8)")
 	var headerFlags headerSlice
 	flag.Var(&headerFlags, "header", "HTTP header in 'Key: Value' format. May be repeated")
 	flag.Parse()
@@ -96,6 +97,17 @@ func main() {
 			*quiet = true
 		case "show-source":
 			*showSourceFlag = true
+		case "timeout":
+			val := ""
+			if len(parts) == 2 {
+				val = parts[1]
+			} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				val = args[i+1]
+				i++
+			}
+			if t, err := strconv.Atoi(val); err == nil {
+				*timeout = t
+			}
 		case "header":
 			val := ""
 			if len(parts) == 2 {
@@ -185,6 +197,11 @@ func main() {
 			}
 		}
 		scan.SetExtraHeaders(h)
+	}
+
+	// Set the render timeout if specified
+	if *timeout > 0 {
+		scan.SetRenderSleepDuration(*timeout)
 	}
 
 	extractor := scan.NewExtractor(*safe, *longSecret)

--- a/internal/scan/constants.go
+++ b/internal/scan/constants.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Timeouts and delays
-const (
+var (
 	// RenderTimeout is the timeout for page rendering operations
 	RenderTimeout = 15 * time.Second
 
@@ -25,6 +25,11 @@ const (
 	// HTTPClientTimeout is the timeout for HTTP requests
 	HTTPClientTimeout = 10 * time.Second
 )
+
+// SetRenderSleepDuration allows customizing the sleep duration for page rendering
+func SetRenderSleepDuration(seconds int) {
+	RenderSleepDuration = time.Duration(seconds) * time.Second
+}
 
 // Other limits
 const (


### PR DESCRIPTION
## Summary
- Added `--timeout` flag to control how long JSMiner waits for dynamic content when rendering pages
- Default value remains 8 seconds (backward compatible)
- Allows users to optimize for speed vs content capture completeness

## Changes
- Added `--timeout` integer flag in main.go with default value of 8 seconds
- Converted `RenderSleepDuration` from constant to variable in constants.go
- Added `SetRenderSleepDuration()` function to update the duration
- Integrated timeout parsing and application in the command-line interface

## Usage
```bash
# Fast scan with 2-second timeout
jsminer https://example.com --timeout 2

# Thorough scan with 15-second timeout for slow-loading sites
jsminer https://example.com --timeout 15

# Use default 8-second timeout
jsminer https://example.com
```

## Test plan
- [ ] Test with default timeout (no flag)
- [ ] Test with shorter timeout (--timeout 2)
- [ ] Test with longer timeout (--timeout 15)
- [ ] Verify help text displays correctly
- [ ] Ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)