### PR TITLE
Add insecure flag to skip TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Flags:
 - `-proxy` run as HTTP/HTTPS proxy on the specified address (e.g. `:8080`).
 - `-targets` file with additional URLs/paths to scan, one per line.
 - `-plugins` comma-separated list of Go plugins providing custom rules.
+- `-insecure` skip TLS certificate verification for HTTPS requests (default `true`).
 - `-header` HTTP header in `Key: Value` form. May be specified multiple times.
 
 Using `-render` requires Chrome or Chromium to be installed on your system.

--- a/cmd/jsminer/main.go
+++ b/cmd/jsminer/main.go
@@ -39,6 +39,7 @@ func main() {
 	posts := flag.Bool("posts", false, "only return HTTP POST request endpoints")
 	external := flag.Bool("external", true, "follow external scripts and imports")
 	render := flag.Bool("render", true, "render pages in headless Chrome")
+	insecure := flag.Bool("insecure", true, "skip TLS certificate verification")
 	longSecret := flag.Bool("longsecret", false, "detect generic long secrets")
 	outFile := flag.String("output", "", "output file (stdout default)")
 	quiet := flag.Bool("quiet", false, "suppress banner")
@@ -102,6 +103,19 @@ func main() {
 			*quiet = true
 		case "show-source":
 			*showSourceFlag = true
+		case "insecure":
+			val := "true"
+			if len(parts) == 2 {
+				val = parts[1]
+			} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				val = args[i+1]
+				i++
+			}
+			if b, err := strconv.ParseBool(val); err == nil {
+				*insecure = b
+			} else {
+				*insecure = true
+			}
 		case "timeout":
 			val := ""
 			if len(parts) == 2 {
@@ -210,6 +224,7 @@ func main() {
 	if *timeout > 0 {
 		scan.SetRenderSleepDuration(*timeout)
 	}
+	scan.SetSkipTLSVerification(*insecure)
 
 	extractor := scan.NewExtractor(*safe, *longSecret)
 	if *rulesFile != "" {

--- a/internal/scan/constants.go
+++ b/internal/scan/constants.go
@@ -24,11 +24,20 @@ var (
 
 	// HTTPClientTimeout is the timeout for HTTP requests
 	HTTPClientTimeout = 10 * time.Second
+
+	// SkipTLSVerification controls whether HTTPS certificate verification is skipped
+	// Defaults to true so invalid certificates are accepted unless explicitly disabled
+	SkipTLSVerification = true
 )
 
 // SetRenderSleepDuration allows customizing the sleep duration for page rendering
 func SetRenderSleepDuration(seconds int) {
 	RenderSleepDuration = time.Duration(seconds) * time.Second
+}
+
+// SetSkipTLSVerification configures whether HTTPS certificate verification should be skipped
+func SetSkipTLSVerification(skip bool) {
+	SkipTLSVerification = skip
 }
 
 // Other limits

--- a/internal/scan/fetch_test.go
+++ b/internal/scan/fetch_test.go
@@ -50,3 +50,24 @@ func TestFetchURLExtraHeaders(t *testing.T) {
 		t.Fatalf("expected header X-Test yes, got %q", hv)
 	}
 }
+
+// Test that FetchURL can skip TLS verification when configured
+func TestFetchURLSkipTLSVerify(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "ok")
+	}))
+	defer ts.Close()
+
+	SetSkipTLSVerification(false)
+	if _, err := FetchURL(ts.URL); err == nil {
+		t.Fatalf("expected TLS error when verification enabled")
+	}
+
+	SetSkipTLSVerification(true)
+	rc, err := FetchURL(ts.URL)
+	if err != nil {
+		t.Fatalf("FetchURL returned error with skip verify: %v", err)
+	}
+	rc.Close()
+	SetSkipTLSVerification(true)
+}

--- a/internal/scan/render.go
+++ b/internal/scan/render.go
@@ -23,6 +23,9 @@ func RenderURL(urlStr string) ([]byte, []string, error) {
 		chromedp.Flag("disable-gpu", true),
 		chromedp.Flag("no-sandbox", true),
 	)
+	if SkipTLSVerification {
+		opts = append(opts, chromedp.Flag("ignore-certificate-errors", true))
+	}
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	defer cancel()
 
@@ -88,6 +91,9 @@ func RenderURLWithRequests(urlStr string) ([]byte, []string, []HTTPRequest, erro
 		chromedp.Flag("disable-gpu", true),
 		chromedp.Flag("no-sandbox", true),
 	)
+	if SkipTLSVerification {
+		opts = append(opts, chromedp.Flag("ignore-certificate-errors", true))
+	}
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	defer cancel()
 

--- a/internal/scan/urlscan.go
+++ b/internal/scan/urlscan.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"bytes"
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,8 +15,17 @@ import (
 // fetchURLResponse retrieves a URL and returns the http.Response
 // with limited redirects and a default User-Agent.
 func fetchURLResponse(u string) (*http.Response, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if SkipTLSVerification {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		} else {
+			transport.TLSClientConfig.InsecureSkipVerify = true
+		}
+	}
 	client := http.Client{
-		Timeout: 10 * time.Second,
+		Transport: transport,
+		Timeout:   10 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return http.ErrUseLastResponse


### PR DESCRIPTION
## Summary
- add `-insecure` flag to ignore invalid HTTPS certificates
- allow skipping TLS verification for `FetchURL`, URL scanning, and rendering
- expose `SetSkipTLSVerification` configuration
- document insecure option
- test TLS skip behaviour
- default to skipping TLS verification

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a26113358833192ac196272e411cf